### PR TITLE
feature/nav : modify subnav size and hovering it

### DIFF
--- a/css/components/nav.css
+++ b/css/components/nav.css
@@ -25,6 +25,7 @@
 }
 
 .material-icons-outlined.md-nav-icon:hover {
+  cursor: pointer;
   color: var(--nav_icon_hover);
 }
 
@@ -56,7 +57,7 @@
   position: absolute;
   left: 80px;
   top: 60px;
-  width: 220px;
+  width: 160px;
   height: calc(100% - 100px);
   list-style: none;
   background: var(--sub_nav_color);
@@ -69,8 +70,8 @@
 }
 
 #subnav:checked + #subnav--toggle {
-  flex-direction: column;
   display: flex;
+  flex-direction: column;
   padding: 20px 30px;
   color: var(--nav_icon_hover);
 }
@@ -83,5 +84,9 @@
 .subnav--toggle__subject {
   padding-left: 5px;
   line-height: 34.82px;
-  color: white;
+  color: var(--sub_nav_font_color);
+}
+
+.subnav--toggle__subject:hover {
+  color: var(--sub_nav_font_hover);
 }

--- a/css/preset/layout_subnav_desktop.css
+++ b/css/preset/layout_subnav_desktop.css
@@ -27,12 +27,21 @@ body {
 }
 
 .fixed--title {
-  color: var(--white);
   padding-bottom: 15px;
+  color: var(--white);
 }
 
 .fixed--subject {
-  line-height: 34.82px;
+  margin-right: 112px;
   padding-left: 5px;
-  color: white;
+  line-height: 34.82px;
+  color: var(--sub_nav_font_color);
+}
+
+.fixed--subject:hover {
+  color: var(--sub_nav_font_hover);
+}
+
+.fixed--subject--active {
+  color: var(--sub_nav_font_hover);
 }

--- a/css/preset/variables.css
+++ b/css/preset/variables.css
@@ -4,7 +4,8 @@
   --nav_icon_hover: #dbdadd;
   --nav_font_color: #585d6c;
   --sub_nav_color: #24262e;
-  --sub_nav_font_color: #686e72;
+  --sub_nav_font_color: #666e80;
+  --sub_nav_font_hover: #f2f2f2;
   --main_footer_bg_color: #fafafa;
   --home_font_color: #25252b;
   --font_dark: #2c2c34;

--- a/pages/day00.html
+++ b/pages/day00.html
@@ -47,7 +47,7 @@
       <div class="layout__subnav">
         <ul class="subnav__fixed">
           <li class="fixed--title text-bold"><h3>PROJECTS</h3></li>
-          <li class="fixed--subject">
+          <li class="fixed--subject fixed--subject--active">
             <a href="day00.html">DAY00</a>
           </li>
           <li class="fixed--subject">

--- a/pages/day01.html
+++ b/pages/day01.html
@@ -50,7 +50,7 @@
           <li class="fixed--subject">
             <a href="day00.html">DAY00</a>
           </li>
-          <li class="fixed--subject">
+          <li class="fixed--subject fixed--subject--active">
             <a href="day01.html">DAY01</a>
           </li>
           <li class="fixed--subject">

--- a/pages/day02.html
+++ b/pages/day02.html
@@ -53,7 +53,7 @@
           <li class="fixed--subject">
             <a href="day01.html">DAY01</a>
           </li>
-          <li class="fixed--subject">
+          <li class="fixed--subject fixed--subject--active">
             <a href="day02.html">DAY02</a>
           </li>
           <li class="fixed--subject">

--- a/pages/day03.html
+++ b/pages/day03.html
@@ -56,7 +56,7 @@
           <li class="fixed--subject">
             <a href="day02.html">DAY02</a>
           </li>
-          <li class="fixed--subject">
+          <li class="fixed--subject fixed--subject--active">
             <a href="day03.html">DAY03</a>
           </li>
           <li class="fixed--subject">

--- a/pages/day04.html
+++ b/pages/day04.html
@@ -59,7 +59,7 @@
           <li class="fixed--subject">
             <a href="day03.html">DAY03</a>
           </li>
-          <li class="fixed--subject">
+          <li class="fixed--subject fixed--subject--active">
             <a href="day04.html">DAY04</a>
           </li>
           <li class="fixed--subject">

--- a/pages/day05.html
+++ b/pages/day05.html
@@ -62,7 +62,7 @@
           <li class="fixed--subject">
             <a href="day04.html">DAY04</a>
           </li>
-          <li class="fixed--subject">
+          <li class="fixed--subject fixed--subject--active">
             <a href="day05.html">DAY05</a>
           </li>
           <li class="fixed--subject">

--- a/pages/rush.html
+++ b/pages/rush.html
@@ -65,7 +65,7 @@
           <li class="fixed--subject">
             <a href="day05.html">DAY05</a>
           </li>
-          <li class="fixed--subject">
+          <li class="fixed--subject fixed--subject--active">
             <a href="rush.html">RUSH</a>
           </li>
         </ul>


### PR DESCRIPTION
Fix
- subnav 사이즈가 달라지는 문제 해결했습니다
- subnav의 글씨 색깔이 white였던걸 모두 수정했습니다
- subnav에 hover 적용했습니다
- subject page에서 day00을 보고 있다면 subnav의 day00 텍스트 색상을 변경하는 방식(hover와 동일한 색상)으로 좀 더 보기 편하게 만들었습니다.
- subnav의 각 item의 width가 gird size만큼 잡혀서 hover가 원치 않은 영역에서도 작동하길래 margin 줘서 고쳤습니다
- 저희 contribution 규칙과 맞지 않는게 몇 개 보여서 수정했습니다.

---
+)
1. 아까(?) 점심때 쯤 하던 토글 뭔가 해결 방법이 있는거 같아 고민중입니다. 모바일 뷰까지 생각하면 토글을 완벽하게 이해해놓는게 좋을 것 같더라구요
2. hover를 넣으니 day00 day01 ... 에 아이콘을 이미지로 박기 애매해져서 병아리는 쓰기 쉽지 않을 것 같은데 font awesome에 그래도 적당한 새(훨훨나는 새) 아이콘들이 있길래 갖다 쓸까 고민중인데 어케 생각하는지요

<img width="957" alt="Screen Shot 2021-10-27 at 11 45 50 PM" src="https://user-images.githubusercontent.com/79127797/139089688-01902986-9dbd-4b7e-abd5-a301706e90eb.png">

day는 키위새 rush 는 비둘기를 할까 생각중이긴 한데 그냥 계란을 박을지 고민이 되네여 의견 있으면 공유 부탁드립니다

3. 마지막으로 깃허브에 이슈 및 PR 템플릿을 만들 수 있던데 어케 생각하시나여? (해보고싶음) 